### PR TITLE
ci-c-util: support running with sanitizers

### DIFF
--- a/.github/workflows/ci-c-util.yml
+++ b/.github/workflows/ci-c-util.yml
@@ -42,6 +42,11 @@ on:
         description: "Additional arguments to meson setup"
         required: false
         type: string
+      sanitizers:
+        default: ""
+        description: "Build and test with specified sanitizers"
+        required: false
+        type: string
       source:
         default: "."
         description: "File system path to the source directory relative to the workspace"
@@ -88,6 +93,7 @@ jobs:
         CTX_INPUTS_MACOS: ${{ inputs.macos }}
         CTX_INPUTS_MATRIXMODE: ${{ inputs.matrixmode }}
         CTX_INPUTS_MESONARGS: ${{ inputs.mesonargs }}
+        CTX_INPUTS_SANITIZERS: ${{ inputs.sanitizers }}
         CTX_INPUTS_SOURCE: ${{ inputs.source }}
         CTX_INPUTS_VALGRIND: ${{ inputs.valgrind }}
         CTX_INPUTS_WINDOWS: ${{ inputs.windows }}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -116,6 +116,7 @@ target "virtual-ci-c-util" {
                         "cargo",
                         "clang",
                         "clang-devel",
+                        "compiler-rt",
                         "coreutils",
                         "curl",
                         "dbus-daemon",

--- a/src/script/ci-c-util-suite.sh
+++ b/src/script/ci-c-util-suite.sh
@@ -23,6 +23,7 @@ CAB_MACOS="false"
 CAB_MATRIX_M32=()
 CAB_MATRIXMODE="false"
 CAB_MESONARGS=""
+CAB_SANITIZERS=""
 CAB_SOURCE="."
 CAB_VALGRIND="false"
 CAB_WINDOWS="false"
@@ -70,6 +71,7 @@ if [[ ${CTX_INPUTS_WINDOWS} == "true" ]] ; then
 fi
 
 CAB_MESONARGS=$(jq -cRs . < <(printf "%s" "${CTX_INPUTS_MESONARGS}"))
+CAB_SANITIZERS=$(jq -cRs . < <(printf "%s" "${CTX_INPUTS_SANITIZERS}"))
 CAB_SOURCE=$(jq -cRs . < <(printf "%s" "${CTX_INPUTS_SOURCE}"))
 
 CAB_MATRIX_M32=("${CAB_M32}")
@@ -88,6 +90,7 @@ for CAB_J in "${CAB_MATRIX_M32[@]}" ; do
                 CAB_JSON+="\"job\":\"${CAB_I}\""
                 CAB_JSON+=",\"m32\":${CAB_J}"
                 CAB_JSON+=",\"mesonargs\":${CAB_MESONARGS}"
+                CAB_JSON+=",\"sanitizers\":${CAB_SANITIZERS}"
                 CAB_JSON+=",\"source\":${CAB_SOURCE}"
                 CAB_JSON+=",\"valgrind\":${CAB_VALGRIND}"
                 CAB_JSON+="},"
@@ -113,6 +116,7 @@ for CAB_J in "${CAB_MATRIX_M32[@]}" ; do
                 CAB_JSON+="\"job\":\"${CAB_I}\""
                 CAB_JSON+=",\"m32\":${CAB_J}"
                 CAB_JSON+=",\"mesonargs\":${CAB_MESONARGS}"
+                CAB_JSON+=",\"sanitizers\":${CAB_SANITIZERS}"
                 CAB_JSON+=",\"source\":${CAB_SOURCE}"
                 CAB_JSON+=",\"valgrind\":${CAB_VALGRIND}"
                 CAB_JSON+="},"
@@ -138,6 +142,7 @@ for CAB_J in "${CAB_MATRIX_M32[@]}" ; do
                 CAB_JSON+="\"job\":\"${CAB_I}\""
                 CAB_JSON+=",\"m32\":${CAB_J}"
                 CAB_JSON+=",\"mesonargs\":${CAB_MESONARGS}"
+                CAB_JSON+=",\"sanitizers\":${CAB_SANITIZERS}"
                 CAB_JSON+=",\"source\":${CAB_SOURCE}"
                 CAB_JSON+=",\"valgrind\":${CAB_VALGRIND}"
                 CAB_JSON+="},"


### PR DESCRIPTION
Support building and testing with various sanitizers (currently only
ASan and UBsan are supported out of the box).

Signed-off-by: Frantisek Sumsal <frantisek@sumsal.cz>

---

Hey!

I finally got some time to work on https://github.com/bus1/dbus-broker/issues/281#issuecomment-1124909292 and this is the first take. The idea is to run the test suite in the bus1/dbus-broker repository with a snippet like:

```yml
  ci-sanitizers:
    name: CI with Address and Undefined Behavior sanitizers
    uses: bus1/cabuild/.github/workflows/ci-c-util.yml@v1
    with:
      cabuild_ref: "v1"
      matrixmode: true
      sanitizers: "address,undefined"
```

Unfortunately, I can't easily test this without reconfiguring image locations and pushing everything where it needs to be, so any insight or comments are very welcome.

/cc @evverx